### PR TITLE
fix(preview): preview fails when `qr-target` set to "dev-build"

### DIFF
--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -18,7 +18,7 @@ export const MESSAGE_ID = 'projectId:{projectId}';
 
 export function previewInput() {
   const qrTarget = getInput('qr-target') || undefined;
-  if (qrTarget && !['expo-go', 'dev-client'].includes(qrTarget)) {
+  if (qrTarget && !['expo-go', 'dev-build', 'dev-client'].includes(qrTarget)) {
     throw new Error(`Invalid QR code target: "${qrTarget}", expected "expo-go" or "dev-build"`);
   }
 

--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -28,7 +28,7 @@ export function previewInput() {
     commentId: getInput('comment-id') || MESSAGE_ID,
     workingDirectory: getInput('working-directory'),
     githubToken: getInput('github-token'),
-    // Note, `dev-build` is prefered, but `dev-client` is supported to aovid confusion
+    // Note, `dev-build` is prefered, but `dev-client` is supported to avoid confusion
     qrTarget: qrTarget as undefined | 'expo-go' | 'dev-build' | 'dev-client',
   };
 }


### PR DESCRIPTION
The qrTarget defensive check does not include the documented (and recommended) `'dev-build'` value, so the action fails with:

__Error: Invalid QR code target: "dev-build", expected "expo-go" or "dev-build"__

### Linked issue
Provide the issue(s) which this pull request relates to or fixes.

### Additional context
Are there things the maintainers should be aware of before merging or closing this pull request?
